### PR TITLE
Do not use PDU name, use control packets to match spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 [ ![Codeship Status for FluuxIO/gomqtt](https://app.codeship.com/projects/75c09d70-d43d-0135-b59a-12b6e6b26eee/status?branch=master)](https://app.codeship.com/projects/262977) [![Build status](https://ci.appveyor.com/api/projects/status/j3ws3b959b5vdg9j?svg=true)](https://ci.appveyor.com/project/mremond/gomqtt)
  [![codecov](https://codecov.io/gh/FluuxIO/gomqtt/branch/master/graph/badge.svg)](https://codecov.io/gh/FluuxIO/gomqtt)
 
-This is an MQTT v3.1.1 client library written in Go.
-
-The library is inspired by my Go XMPP library (gox) and tries to use similar consistent API.
+Fluux MQTT is a MQTT v3.1.1 client library written in Go.
 
 The library has been tested with the following MQTT servers:
 

--- a/mqtt/client.go
+++ b/mqtt/client.go
@@ -143,7 +143,7 @@ func (c *Client) Connect(defaultMsgChannel chan<- Message) error {
 // Disconnect sends DISCONNECT MQTT packet to other party and clean up
 // the client state.
 func (c *Client) Disconnect() {
-	packet := PDUDisconnect{}
+	packet := DisconnectPacket{}
 	c.send(&packet)
 	c.sender.quit <- struct{}{}
 
@@ -159,14 +159,14 @@ func (c *Client) Disconnect() {
 // Subscribe sends SUBSCRIBE MQTT control packet.  At the moment
 // suscribe are not kept in client state and are lost on reconnection.
 func (c *Client) Subscribe(topic Topic) {
-	subscribe := PDUSubscribe{}
+	subscribe := SubscribePacket{}
 	subscribe.Topics = append(subscribe.Topics, topic)
 	c.send(&subscribe)
 }
 
 // Unsubscribe sends UNSUBSCRIBE MQTT control packet.
 func (c *Client) Unsubscribe(topic string) {
-	unsubscribe := PDUUnsubscribe{}
+	unsubscribe := UnsubscribePacket{}
 	unsubscribe.Topics = append(unsubscribe.Topics, topic)
 	c.send(&unsubscribe)
 }
@@ -175,7 +175,7 @@ func (c *Client) Unsubscribe(topic string) {
 
 // Publish sends PUBLISH MQTT control packet.
 func (c *Client) Publish(topic string, payload []byte) {
-	publish := PDUPublish{}
+	publish := PublishPacket{}
 	publish.Topic = topic
 	publish.Payload = payload
 	c.send(&publish)
@@ -192,7 +192,7 @@ func (c *Client) connect() error {
 
 	// 1. Open session - Login
 	// Send connect packet
-	connectPacket := PDUConnect{ProtocolLevel: c.ProtocolLevel, ProtocolName: "MQTT"}
+	connectPacket := ConnectPacket{ProtocolLevel: c.ProtocolLevel, ProtocolName: "MQTT"}
 	connectPacket.Keepalive = c.Keepalive
 	connectPacket.ClientID = c.ClientID
 	connectPacket.CleanSession = c.CleanSession
@@ -206,7 +206,7 @@ func (c *Client) connect() error {
 	}
 
 	switch p := connack.(type) {
-	case PDUConnAck:
+	case ConnAckPacket:
 		switch p.ReturnCode {
 		case ConnAccepted:
 		default:

--- a/mqtt/client_test.go
+++ b/mqtt/client_test.go
@@ -180,7 +180,7 @@ func (mock *MQTTServerMock) loopCleanup() {
 
 // handlerConnackSuccess sends connack to client without even reading from socket.
 func handlerConnackSuccess(_ *testing.T, c net.Conn) {
-	ack := mqtt.PDUConnAck{}
+	ack := mqtt.ConnAckPacket{}
 	buf := ack.Marshall()
 	c.Write(buf)
 }
@@ -197,11 +197,11 @@ func handlerUnauthorized(t *testing.T, c net.Conn) {
 	c.SetReadDeadline(time.Time{})
 
 	switch pType := p.(type) {
-	case mqtt.PDUConnect:
+	case mqtt.ConnectPacket:
 		if pType.ClientID != "testClientID" {
 			t.Error("connect packet is not properly parsed")
 		}
-		ack := mqtt.PDUConnAck{ReturnCode: mqtt.ConnRefusedBadUsernameOrPassword}
+		ack := mqtt.ConnAckPacket{ReturnCode: mqtt.ConnRefusedBadUsernameOrPassword}
 		buf := ack.Marshall()
 		c.Write(buf)
 	default:

--- a/mqtt/control_packets_test.go
+++ b/mqtt/control_packets_test.go
@@ -12,7 +12,7 @@ import (
 
 // TODO: Test incorrect will QOS
 func TestIncrementalConnectFlag(t *testing.T) {
-	c := PDUConnect{}
+	c := ConnectPacket{}
 	assertConnectFlagValue(t, "incorrect connect flag: default connect flag should be empty (%d)", c.connectFlag(), 0)
 
 	c.CleanSession = true
@@ -37,8 +37,8 @@ func TestIncrementalConnectFlag(t *testing.T) {
 	assertConnectFlagValue(t, "incorrect connect flag: passwordFlag is not properly set (%d)", c.connectFlag(), 246)
 }
 
-func getConnect() PDUConnect {
-	connect := PDUConnect{ProtocolLevel: ProtocolLevel, ProtocolName: ProtocolName}
+func getConnect() ConnectPacket {
+	connect := ConnectPacket{ProtocolLevel: ProtocolLevel, ProtocolName: ProtocolName}
 	connect.CleanSession = true
 	connect.WillFlag = true
 	connect.WillQOS = 1
@@ -61,7 +61,7 @@ func TestConnectDecode(t *testing.T) {
 		t.Errorf("cannot decode connect packet: %q", err)
 	} else {
 		switch p := packet.(type) {
-		case PDUConnect:
+		case ConnectPacket:
 			if p != connect {
 				t.Errorf("unmarshalled connect does not match original (%+v) = %+v", p, connect)
 			}
@@ -95,7 +95,7 @@ func assertConnectFlagValue(t *testing.T, message string, flag int, expected int
 
 func TestConnAckEncodeDecode(t *testing.T) {
 	returnCode := 1
-	ca := &PDUConnAck{}
+	ca := &ConnAckPacket{}
 	ca.ReturnCode = returnCode
 	buf := ca.Marshall()
 
@@ -104,7 +104,7 @@ func TestConnAckEncodeDecode(t *testing.T) {
 		t.Error("cannot decode connack control packet")
 	} else {
 		switch p := packet.(type) {
-		case PDUConnAck:
+		case ConnAckPacket:
 			if p.ReturnCode != returnCode {
 				t.Errorf("incorrect result code (%d) = %d", p.ReturnCode, returnCode)
 			}
@@ -119,7 +119,7 @@ func TestConnAckEncodeDecode(t *testing.T) {
 // ============================================================================
 
 func TestDisconnect(t *testing.T) {
-	disconnect := PDUDisconnect{}
+	disconnect := DisconnectPacket{}
 	buf := disconnect.Marshall()
 
 	reader := bytes.NewReader(buf)
@@ -127,7 +127,7 @@ func TestDisconnect(t *testing.T) {
 		t.Error("cannot decode disconnect control packet")
 	} else {
 		switch packet.(type) {
-		case PDUDisconnect:
+		case DisconnectPacket:
 		default:
 			t.Error("Incorrect packet type for disconnect")
 		}
@@ -139,7 +139,7 @@ func TestDisconnect(t *testing.T) {
 // ============================================================================
 
 func TestPublishDecode(t *testing.T) {
-	publish := PDUPublish{}
+	publish := PublishPacket{}
 	publish.ID = 1
 	publish.Dup = false
 	publish.Qos = 1
@@ -153,7 +153,7 @@ func TestPublishDecode(t *testing.T) {
 		t.Errorf("cannot decode publish packet: %q", err)
 	} else {
 		switch p := packet.(type) {
-		case PDUPublish:
+		case PublishPacket:
 			if p.Dup != publish.Dup {
 				t.Errorf("incorrect dup flag (%t) = %t", p.Dup, publish.Dup)
 			}
@@ -185,7 +185,7 @@ func TestPublishDecode(t *testing.T) {
 
 func TestPubAckEncodeDecode(t *testing.T) {
 	id := 1500
-	pa := &PDUPubAck{}
+	pa := &PubAckPacket{}
 	pa.ID = id
 	buf := pa.Marshall()
 
@@ -194,7 +194,7 @@ func TestPubAckEncodeDecode(t *testing.T) {
 		t.Error("cannot decode puback control packet")
 	} else {
 		switch p := packet.(type) {
-		case PDUPubAck:
+		case PubAckPacket:
 			if p.ID != id {
 				t.Errorf("incorrect packet id (%d) = %d", p.ID, id)
 			}
@@ -210,7 +210,7 @@ func TestPubAckEncodeDecode(t *testing.T) {
 // ============================================================================
 
 func TestSubscribeDecode(t *testing.T) {
-	subscribe := PDUSubscribe{}
+	subscribe := SubscribePacket{}
 	subscribe.ID = 2
 
 	t1 := Topic{Name: "test/topic", QOS: 0}
@@ -225,7 +225,7 @@ func TestSubscribeDecode(t *testing.T) {
 		t.Errorf("cannot decode subscribe packet: %q", err)
 	} else {
 		switch p := packet.(type) {
-		case PDUSubscribe:
+		case SubscribePacket:
 			if p.ID != subscribe.ID {
 				t.Errorf("incorrect packet id (%d) = %d", p.ID, subscribe.ID)
 			}
@@ -257,7 +257,7 @@ func TestSubscribeDecode(t *testing.T) {
 
 func TestSubAckEncodeDecode(t *testing.T) {
 	id := 1500
-	sa := &PDUSubAck{}
+	sa := &SubAckPacket{}
 	sa.ID = id
 	sa.ReturnCodes = []int{0x00, 0x01, 0x02, 0x80}
 	buf := sa.Marshall()
@@ -267,7 +267,7 @@ func TestSubAckEncodeDecode(t *testing.T) {
 		t.Error("cannot decode connack control packet")
 	} else {
 		switch p := packet.(type) {
-		case PDUSubAck:
+		case SubAckPacket:
 			if p.ID != sa.ID {
 				t.Errorf("incorrect packet id (%d) = %d", p.ID, sa.ID)
 			}
@@ -289,7 +289,7 @@ func TestSubAckEncodeDecode(t *testing.T) {
 // ============================================================================
 
 func TestUnsubscribeDecode(t *testing.T) {
-	unsub := PDUUnsubscribe{}
+	unsub := UnsubscribePacket{}
 	unsub.ID = 2000
 
 	t1 := "test/topic"
@@ -304,7 +304,7 @@ func TestUnsubscribeDecode(t *testing.T) {
 		t.Errorf("cannot decode unsubscribe packet: %q", err)
 	} else {
 		switch p := packet.(type) {
-		case PDUUnsubscribe:
+		case UnsubscribePacket:
 			if p.ID != unsub.ID {
 				t.Errorf("incorrect packet id (%d) = %d", p.ID, unsub.ID)
 			}
@@ -332,7 +332,7 @@ func TestUnsubscribeDecode(t *testing.T) {
 
 func TestUnsubAckEncodeDecode(t *testing.T) {
 	id := 1000
-	ua := &PDUUnsubAck{}
+	ua := &UnsubAckPacket{}
 	ua.ID = id
 	buf := ua.Marshall()
 
@@ -341,7 +341,7 @@ func TestUnsubAckEncodeDecode(t *testing.T) {
 		t.Error("cannot decode unsuback control packet")
 	} else {
 		switch p := packet.(type) {
-		case PDUUnsubAck:
+		case UnsubAckPacket:
 			if p.ID != ua.ID {
 				t.Errorf("incorrect packet id (%d) = %d", p.ID, ua.ID)
 			}
@@ -357,7 +357,7 @@ func TestUnsubAckEncodeDecode(t *testing.T) {
 // ============================================================================
 
 func TestPingReq(t *testing.T) {
-	pingReq := PDUPingReq{}
+	pingReq := PingReqPacket{}
 	buf := pingReq.Marshall()
 
 	reader := bytes.NewReader(buf)
@@ -365,7 +365,7 @@ func TestPingReq(t *testing.T) {
 		t.Error("cannot decode pingreq control packet")
 	} else {
 		switch packet.(type) {
-		case PDUPingReq:
+		case PingReqPacket:
 
 		default:
 			t.Error("Incorrect packet type for pingreq")
@@ -379,7 +379,7 @@ func TestPingReq(t *testing.T) {
 // ============================================================================
 
 func TestPingResp(t *testing.T) {
-	pingResp := PDUPingResp{}
+	pingResp := PingRespPacket{}
 	buf := pingResp.Marshall()
 
 	reader := bytes.NewReader(buf)
@@ -387,7 +387,7 @@ func TestPingResp(t *testing.T) {
 		t.Error("cannot decode pingresp control packet")
 	} else {
 		switch p := packet.(type) {
-		case PDUPingResp:
+		case PingRespPacket:
 
 		default:
 			t.Error("Incorrect packet type for pingresp: ", reflect.TypeOf(p).Elem())

--- a/mqtt/encoding.go
+++ b/mqtt/encoding.go
@@ -87,27 +87,27 @@ func ConnAckError(returnCode int) error {
 func Decode(packetType int, fixedHeaderFlags int, payload []byte) Marshaller {
 	switch packetType {
 	case connectType:
-		return pduConnect.decode(payload)
+		return connectPacket.decode(payload)
 	case connackType:
-		return pduConnAck.decode(payload)
+		return connAckPacket.decode(payload)
 	case publishType:
-		return pduPublish.decode(fixedHeaderFlags, payload)
+		return publishPacket.decode(fixedHeaderFlags, payload)
 	case pubackType:
-		return pduPubAck.decode(payload)
+		return pubAckPacket.decode(payload)
 	case subscribeType:
-		return pduSubscribe.decode(payload)
+		return subscribePacket.decode(payload)
 	case subackType:
-		return pduSubAck.decode(payload)
+		return subAckPacket.decode(payload)
 	case unsubscribeType:
-		return pduUnsubscribe.decode(payload)
+		return unsubscribePacket.decode(payload)
 	case unsubackType:
-		return pduUnsubAck.decode(payload)
+		return unsubAckPacket.decode(payload)
 	case pingreqType:
-		return pduPingReq.decode(payload)
+		return pingReqPacket.decode(payload)
 	case pingrespType:
-		return pduPingResp.decode(payload)
+		return pingRespPacket.decode(payload)
 	case disconnectType:
-		return pduDisconnect.decode(payload)
+		return disconnectPacket.decode(payload)
 	default: // Unsupported MQTT packet type
 		return nil
 	}

--- a/mqtt/receiver.go
+++ b/mqtt/receiver.go
@@ -38,7 +38,7 @@ Loop:
 
 		// Only broadcast message back to client when we receive publish packets
 		switch packetType := p.(type) {
-		case PDUPublish:
+		case PublishPacket:
 			m := Message{}
 			m.Topic = packetType.Topic
 			m.Payload = packetType.Payload
@@ -55,9 +55,9 @@ Loop:
 // Send acks if needed, depending on packet QOS
 func sendAckIfNeeded(pkt Marshaller, s sender) {
 	switch p := pkt.(type) {
-	case PDUPublish:
+	case PublishPacket:
 		if p.Qos == 1 {
-			puback := PDUPubAck{ID: p.ID}
+			puback := PubAckPacket{ID: p.ID}
 			buf := puback.Marshall()
 			s.send(buf)
 		}

--- a/mqtt/sender.go
+++ b/mqtt/sender.go
@@ -26,7 +26,7 @@ func initSender(conn net.Conn, keepalive int) sender {
 	var keepaliveCtl chan int
 	if keepalive > 0 {
 		keepaliveCtl = startKeepalive(keepalive, func() {
-			pingReq := PDUPingReq{}
+			pingReq := PingReqPacket{}
 			buf := pingReq.Marshall()
 			conn.Write(buf)
 		})


### PR DESCRIPTION
I used Packet prefix instead of CP prefix, as it seems more legible, but a bit longer.

Which one do you prefer finally ?

See #gomqtt-4
  